### PR TITLE
Use winsock.h instead of sys/time.h for timeval for MSVC

### DIFF
--- a/libacars/reassembly.h
+++ b/libacars/reassembly.h
@@ -10,7 +10,11 @@
 extern "C" {
 #endif
 #include <stdbool.h>
+#ifndef _MSC_VER
 #include <sys/time.h>
+#else
+#include <winsock.h>
+#endif
 #include <libacars/hash.h>
 
 typedef struct la_reasm_ctx_s la_reasm_ctx;


### PR DESCRIPTION
This patch allows the windows binary release to be used with Microsoft Visual Studio, which doesn't have sys/time.h.