### PR TITLE
Add support for compilation with MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,9 +21,13 @@ endif(NOT CMAKE_BUILD_TYPE)
 option(EMIT_ASN_DEBUG, "Enable debugging of ASN.1 decoder (requires
 CMAKE_BUILD_TYPE=Debug" OFF)
 
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra")
-set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -Og -DDEBUG")
-set(CMAKE_C_FLAGS_RELEASE "-O2 -DNDEBUG")
+if(MSVC)
+	set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+else()
+	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra")
+	set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -Og -DDEBUG")
+	set(CMAKE_C_FLAGS_RELEASE "-O2 -DNDEBUG")
+endif()
 
 if(MINGW)
 	add_definitions(-D__USE_MINGW_ANSI_STDIO=1)

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The project should build and run correctly on the following platforms:
 
 - Linux i686 and x86_64 (gcc)
 - MacOS (clang)
-- Windows (mingw)
+- Windows (mingw or msvc)
 
 #### Installing dependencies
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -7,7 +7,9 @@ foreach (ex ${EXAMPLE_BINARIES})
 	add_executable(${ex} ${ex}.c)
 	target_link_libraries(${ex} acars)
 endforeach()
-target_link_libraries (cpdlc_get_position m)
+if(NOT MSVC)
+	target_link_libraries (cpdlc_get_position m)
+endif()
 install (TARGETS
 	${EXAMPLE_BINARIES}
 	DESTINATION ${CMAKE_INSTALL_BINDIR}

--- a/libacars/CMakeLists.txt
+++ b/libacars/CMakeLists.txt
@@ -79,8 +79,12 @@ if(NOT ${LFIND_NMEMB_SIZE_SIZE_T} AND NOT ${LFIND_NMEMB_SIZE_UINT})
 	message(FATAL_ERROR "Unable to determine lfind function prototype")
 endif()
 
+CHECK_INCLUDE_FILE("sys/time.h" HAVE_SYS_TIME_H)
+CHECK_INCLUDE_FILE("unistd.h" HAVE_UNISTD_H)
 
-find_library(LIBM m REQUIRED)
+if(NOT MSVC)
+	find_library(LIBM m REQUIRED)
+endif()
 
 option(ZLIB "Enable ZLIB support for MIAM" ON)
 set(WITH_ZLIB FALSE)
@@ -163,7 +167,11 @@ target_include_directories(acars_core PUBLIC ${acars_include_dirs} ${CMAKE_CURRE
 set(acars_obj_files $<TARGET_OBJECTS:asn1> $<TARGET_OBJECTS:acars_core>)
 
 add_library(acars SHARED ${acars_obj_files})
-target_link_libraries (acars m ${acars_extra_libs})
+if(MSVC)
+	target_link_libraries (acars ${acars_extra_libs})
+else()
+	target_link_libraries (acars m ${acars_extra_libs})
+endif()
 set_property (TARGET acars PROPERTY SOVERSION ${LA_VERSION_MAJOR})
 set_target_properties(acars PROPERTIES OUTPUT_NAME "acars-${LA_VERSION_MAJOR}")
 if (HAVE_LD_VERSION_SCRIPT)
@@ -171,7 +179,12 @@ if (HAVE_LD_VERSION_SCRIPT)
 endif()
 
 add_library(acars_static ${acars_obj_files})
-set_target_properties(acars_static PROPERTIES OUTPUT_NAME "acars-${LA_VERSION_MAJOR}")
+if(MSVC)
+    # In order to build with ninja, we need static and shared .lib names to be different
+    set_target_properties(acars_static PROPERTIES OUTPUT_NAME "acarsstatic-${LA_VERSION_MAJOR}")
+else()
+    set_target_properties(acars_static PROPERTIES OUTPUT_NAME "acars-${LA_VERSION_MAJOR}")
+endif()
 
 configure_file(
 	"${CMAKE_CURRENT_SOURCE_DIR}/${PROJECT_NAME}.pc.in"

--- a/libacars/acars.c
+++ b/libacars/acars.c
@@ -5,8 +5,10 @@
  */
 
 #include <string.h>                         // memcpy(), strdup()
+#include "config.h"                         // WITH_LIBXML2, HAVE_SYS_TIME_H
+#ifdef HAVE_SYS_TIME_H
 #include <sys/time.h>                       // struct timeval
-#include "config.h"                         // WITH_LIBXML2
+#endif
 #ifdef WITH_LIBXML2
 #include <libxml/tree.h>                    // xmlBufferPtr, xmlBufferFree()
 #endif

--- a/libacars/asn1-format-cpdlc-json.c
+++ b/libacars/asn1-format-cpdlc-json.c
@@ -17,7 +17,7 @@
 #include <libacars/json.h>                          /* la_json_*() */
 
 // Forward declarations
-static la_asn1_formatter const la_asn1_cpdlc_json_formatter_table[];
+static la_asn1_formatter const la_asn1_cpdlc_json_formatter_table[LA_ASN1_CPDLC_TABLE_SIZE];
 static size_t la_asn1_cpdlc_json_formatter_table_len;
 
 /************************
@@ -204,7 +204,7 @@ static LA_ASN1_FORMATTER_FUNC(la_asn1_format_FANSATCUplinkMsgElementId_as_json) 
 	la_format_CHOICE_as_json(p, FANSATCUplinkMsgElementId_labels, la_asn1_output_cpdlc_as_json);
 }
 
-static la_asn1_formatter const la_asn1_cpdlc_json_formatter_table[] = {
+static la_asn1_formatter const la_asn1_cpdlc_json_formatter_table[LA_ASN1_CPDLC_TABLE_SIZE] = {
 	{ .type = &asn_DEF_FANSAircraftEquipmentCode, .format = la_asn1_format_SEQUENCE_cpdlc_as_json, .label = "ac_equipment_code" },
 	{ .type = &asn_DEF_FANSAircraftFlightIdentification, .format = la_asn1_format_any_as_string_as_json, .label = "ac_flight_id" },
 	{ .type = &asn_DEF_FANSAircraftType, .format = la_asn1_format_any_as_string_as_json, .label = "ac_type" },

--- a/libacars/asn1-format-cpdlc-text.c
+++ b/libacars/asn1-format-cpdlc-text.c
@@ -14,7 +14,7 @@
 #include <libacars/vstring.h>                           // la_vstring
 
 // Forward declarations
-static la_asn1_formatter const la_asn1_cpdlc_text_formatter_table[];
+static la_asn1_formatter const la_asn1_cpdlc_text_formatter_table[LA_ASN1_CPDLC_TABLE_SIZE];
 static size_t la_asn1_cpdlc_text_formatter_table_len;
 
 la_dict const FANSATCUplinkMsgElementId_labels[] = {
@@ -568,7 +568,7 @@ static LA_ASN1_FORMATTER_FUNC(la_asn1_format_FANSATCUplinkMsgElementId_as_text) 
 	la_format_CHOICE_as_text(p, FANSATCUplinkMsgElementId_labels, la_asn1_output_cpdlc_as_text);
 }
 
-static la_asn1_formatter const la_asn1_cpdlc_text_formatter_table[] = {
+static la_asn1_formatter const la_asn1_cpdlc_text_formatter_table[LA_ASN1_CPDLC_TABLE_SIZE] = {
 	{ .type = &asn_DEF_FANSAircraftEquipmentCode, .format = la_asn1_format_SEQUENCE_cpdlc_as_text, .label = NULL },
 	{ .type = &asn_DEF_FANSAircraftFlightIdentification, .format = la_asn1_format_any_as_text, .label = "Flight ID" },
 	{ .type = &asn_DEF_FANSAircraftType, .format = la_asn1_format_any_as_text, .label = "Aircraft type" },

--- a/libacars/asn1-format-cpdlc.h
+++ b/libacars/asn1-format-cpdlc.h
@@ -19,4 +19,6 @@ extern la_dict const FANSATCDownlinkMsgElementId_labels[];
 // asn1-format-cpdlc-json.c
 LA_ASN1_FORMATTER_FUNC(la_asn1_output_cpdlc_as_json);
 
+#define LA_ASN1_CPDLC_TABLE_SIZE 209
+
 #endif // !LA_ASN1_FORMAT_CPDLC_H

--- a/libacars/asn1/asn_internal.h
+++ b/libacars/asn1/asn_internal.h
@@ -103,7 +103,7 @@ static void ASN_DEBUG(const char *fmt, ...) { (void)fmt; }
  * Check stack against overflow, if limit is set.
  */
 #define	ASN__DEFAULT_STACK_MAX	(30000)
-static int __attribute__((unused))
+static int GCC_NOTUSED
 ASN__STACK_OVERFLOW_CHECK(asn_codec_ctx_t *ctx) {
 	if(ctx && ctx->max_stack_size) {
 

--- a/libacars/config.h.in
+++ b/libacars/config.h.in
@@ -12,5 +12,7 @@
 #cmakedefine HAVE_STRSEP
 #cmakedefine LFIND_NMEMB_SIZE_SIZE_T
 #cmakedefine LFIND_NMEMB_SIZE_UINT
+#cmakedefine HAVE_SYS_TIME_H
+#cmakedefine HAVE_UNISTD_H
 
 #endif // !_CONFIG_H

--- a/libacars/json.h
+++ b/libacars/json.h
@@ -15,6 +15,12 @@
 extern "C" {
 #endif
 
+#if	__GNUC__ >= 3
+#define GCC_DEPRECATED(x) __attribute__ ((deprecated(x))
+#else
+#define GCC_DEPRECATED(x)
+#endif
+
 // json.c
 void la_json_object_start(la_vstring *vstr, char const *key);
 void la_json_object_end(la_vstring *vstr);
@@ -24,7 +30,7 @@ void la_json_append_bool(la_vstring *vstr, char const *key, bool val);
 void la_json_append_double(la_vstring *vstr, char const *key, double val);
 void la_json_append_int64(la_vstring *vstr, char const *key, int64_t val);
 void la_json_append_long(la_vstring *vstr, char const *key, long val)
-	__attribute__ ((deprecated("This function is not portable; use la_json_append_int64 instead")));
+	GCC_DEPRECATED("This function is not portable; use la_json_append_int64 instead");
 void la_json_append_char(la_vstring *vstr, char const *key, char val);
 void la_json_append_string(la_vstring *vstr, char const *key, char const *val);
 void la_json_append_octet_string(la_vstring *vstr, char const *key,

--- a/libacars/json.h
+++ b/libacars/json.h
@@ -16,7 +16,7 @@ extern "C" {
 #endif
 
 #if	__GNUC__ >= 3
-#define GCC_DEPRECATED(x) __attribute__ ((deprecated(x))
+#define GCC_DEPRECATED(x) __attribute__ ((deprecated(x)))
 #else
 #define GCC_DEPRECATED(x)
 #endif

--- a/libacars/miam.c
+++ b/libacars/miam.c
@@ -4,11 +4,14 @@
  *  Copyright (c) 2018-2021 Tomasz Lemiech <szpajder@gmail.com>
  */
 
+#include "config.h"                 /* HAVE_SYS_TIME_H */
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdlib.h>                 /* calloc() */
 #include <string.h>                 /* strchr(), strlen(), strncmp(), strcmp() */
+#ifdef HAVE_SYS_TIME_H
 #include <sys/time.h>               /* struct timeval */
+#endif
 #include <libacars/macros.h>        /* la_assert() */
 #include <libacars/libacars.h>      /* la_proto_node, la_type_descriptor */
 #include <libacars/vstring.h>       /* la_vstring */

--- a/libacars/reassembly.c
+++ b/libacars/reassembly.c
@@ -4,7 +4,10 @@
  *  Copyright (c) 2018-2021 Tomasz Lemiech <szpajder@gmail.com>
  */
 
+#include "config.h"                     // HAVE_SYS_TIME_H
+#ifdef HAVE_SYS_TIME_H
 #include <sys/time.h>                   // struct timeval
+#endif
 #include <string.h>                     // strdup
 #include <libacars/macros.h>            // la_assert
 #include <libacars/hash.h>              // la_hash

--- a/libacars/util.c
+++ b/libacars/util.c
@@ -10,8 +10,10 @@
 #include <time.h>               // struct tm
 #include <limits.h>             // CHAR_BIT
 #include <errno.h>              // errno
+#include "config.h"             // HAVE_STRSEP, WITH_LIBXML2, HAVE_UNISTD_H
+#ifdef HAVE_UNISTD_H
 #include <unistd.h>             // _exit
-#include "config.h"             // HAVE_STRSEP, WITH_LIBXML2
+#endif
 #ifdef WITH_LIBXML2
 #include <libxml/parser.h>      // xmlParseDoc
 #include <libxml/tree.h>        // xmlBuffer.*, xmlNodeDump, xmlDocGetRootElement, xmlFreeDoc


### PR DESCRIPTION
Hi,

This PR adds support for compiling libacars with MSVC.

Changes:

- Don't use gcc specific options with MSVC (E.g. -Wall)
- Don't include header files that aren't available (sys/time.h unistd.h)
- Don't try to link with libm 
- CPDLC array size needed to be defined in forward declarations
- Remove use of some GCC attributes when compiling with MSVC